### PR TITLE
- the analyse triger is fired once the event is finished now (prevent…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,6 @@
+0.2.1 [lubolura]
+    - the analyse triger is fired once the event is finished now (prevent missing video file error)
+    - best (maxscored) image frame for analyse is selected from zoneminder database
+
+0.2
+    -

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Requirements
 ================================================================================
 * ZoneMinder with API version 2.0 enabled (tested with ZoneMinder 1.36.32)
 * Python 3 (tested with version 3.10.6)
-* Python modules: setuptools, requests, cv2, numpy, matplotlib
+* Python modules: setuptools, requests, cv2, numpy, matplotlib, mysql (mysql-connector-python)
 * Mutt (if you wish to send notifications via email)
 * Pushover account and api token (if you wish to send notifications via Pushover
   API)

--- a/ZoneMinder_notifier.egg-info/PKG-INFO
+++ b/ZoneMinder_notifier.egg-info/PKG-INFO
@@ -1,0 +1,11 @@
+Metadata-Version: 2.1
+Name: ZoneMinder-notifier
+Version: 0.2.1
+Summary: UNKNOWN
+Home-page: UNKNOWN
+License: UNKNOWN
+Platform: UNKNOWN
+License-File: LICENSE
+
+UNKNOWN
+

--- a/ZoneMinder_notifier.egg-info/SOURCES.txt
+++ b/ZoneMinder_notifier.egg-info/SOURCES.txt
@@ -1,0 +1,13 @@
+LICENSE
+README.md
+setup.py
+zm_api.py
+zm_monitor.py
+zm_notification.py
+zm_object_detection.py
+zm_settings.py
+zm_util.py
+ZoneMinder_notifier.egg-info/PKG-INFO
+ZoneMinder_notifier.egg-info/SOURCES.txt
+ZoneMinder_notifier.egg-info/dependency_links.txt
+ZoneMinder_notifier.egg-info/top_level.txt

--- a/ZoneMinder_notifier.egg-info/top_level.txt
+++ b/ZoneMinder_notifier.egg-info/top_level.txt
@@ -1,0 +1,6 @@
+zm_api
+zm_monitor
+zm_notification
+zm_object_detection
+zm_settings
+zm_util

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name = "ZoneMinder_notifier",
-      version = "0.2",
+      version = "0.2.1",
       py_modules = ["zm_api", "zm_monitor", "zm_notification", "zm_object_detection",
                     "zm_settings", "zm_util"],
       )

--- a/zm_api.py
+++ b/zm_api.py
@@ -213,7 +213,7 @@ class ZMAPI:
 
         # Get the list of events for this monitor in descending order based on StartTime
         monitor_url = self.apipath + '/events/index/MonitorId:{:d}.json'.format(monitorID)
-        r = self._makeRequest(monitor_url, params=['page=1', 'sort=StartTime', 'direction=desc'])
+        r = self._makeRequest(monitor_url, params=['page=1', 'sort=EndTime', 'direction=desc'])
         if not r.ok:
             self.debug(1, "Error getting events in getMonitorLatestEvent", "stderr")
             return res

--- a/zm_util.py
+++ b/zm_util.py
@@ -1,6 +1,8 @@
 import sys
+import mysql.connector
 from datetime import datetime
 from configparser import NoOptionError
+
 
 def debug(message, pipe="stdout"):
 
@@ -73,3 +75,22 @@ def get_float_from_config(config, section, option, required=True, default=None):
         sys.exit(1)
 
     return val
+
+
+def get_highest_scored_image(event):
+    try:
+        conn = mysql.connector.connect(host='localhost',
+                                       database='zm',
+                                       user='zmuser',
+                                       password='zmpass',
+                                       auth_plugin='mysql_native_password')
+        with conn.cursor() as cursor:
+            # Read data from database
+            sql = """select FrameID from Frames where ID = {}""".format(event['maxscore_frameid'])
+            cursor.execute(sql)
+            row = cursor.fetchone()
+            return row[0] if row != None else -1
+    except Exception as e:
+        sys.stderr.write(f"Error to get data from database : {e}\n")
+        return -1
+


### PR DESCRIPTION
- the analyze trigger is fired once the event is finished now (prevent missing video file error), inspired by discussion related to another issue  - changed form StartEvent  to 'sort=EndTime'  - it will solve missing video for analyze... and it will allow to analyze image with highest score within event (not the first one which was catched as soon as StartEvent ocured ...)

- best (maxscored) image frame for analyze is selected from zoneminder database and this is processed for analyze then. There is related change that new self property best_image_for_analyse is introduced , instead of original multiple calls of eventImage(self, event, imgfile="snapshot.jpg") function. In order to select best image from database, there is new function get_highest_scored_image(event) created for select from zoneminder mysql database, in zm_utils module.
